### PR TITLE
[ai-sdk]: Add highlights parameter to webSearch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,9 @@ export function webSearch(config: ExaSearchConfig = {}) {
       }
 
       // Add other content options
+      if (contents.highlights !== undefined) {
+        requestBody.contents.highlights = contents.highlights;
+      }
       if (contents.summary !== undefined) {
         requestBody.contents.summary = contents.summary;
       }
@@ -151,6 +154,7 @@ export type {
   ExaSearchResult,
   ContentsOptions,
   TextOptions,
+  HighlightsOptions,
   SummaryOptions,
   ExtrasOptions,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,18 @@ export interface SummaryOptions {
 }
 
 /**
+ * Highlights options - text snippets the LLM identifies as most relevant from each page
+ */
+export interface HighlightsOptions {
+  /** Number of sentences to return for each snippet */
+  numSentences?: number;
+  /** Number of snippets to return for each result */
+  highlightsPerUrl?: number;
+  /** Custom query to direct the LLM's selection of highlights */
+  query?: string;
+}
+
+/**
  * Extras options
  */
 export interface ExtrasOptions {
@@ -32,6 +44,8 @@ export interface ExtrasOptions {
 export interface ContentsOptions {
   /** Get page text content. Pass true or an object with options (default: {maxCharacters: 1000}) */
   text?: boolean | TextOptions;
+  /** Get text snippets the LLM identifies as most relevant from each page */
+  highlights?: boolean | HighlightsOptions;
   /** Get AI-generated summary */
   summary?: boolean | SummaryOptions;
   /** Livecrawl mode (default: "fallback"): "never", "fallback", "always", "preferred" */
@@ -148,6 +162,10 @@ export interface ExaSearchResult {
   favicon?: string;
   /** Full text content of the page */
   text?: string;
+  /** Array of highlights extracted from the search result content */
+  highlights?: string[];
+  /** Array of cosine similarity scores for each highlight */
+  highlightScores?: number[];
   /** AI-generated summary */
   summary?: string;
   /** Array of subpages */


### PR DESCRIPTION
## Summary

Adds the `highlights` parameter to the `webSearch` tool, allowing users to retrieve LLM-extracted text snippets from search results.

**Changes:**
- New `HighlightsOptions` interface with `numSentences`, `highlightsPerUrl`, and `query` options
- Added `highlights` to `ContentsOptions` (accepts `boolean | HighlightsOptions`)
- Added `highlights` and `highlightScores` fields to `ExaSearchResult` response type
- Exported `HighlightsOptions` type for users

**Usage:**
```typescript
webSearch({
  contents: {
    highlights: { numSentences: 3, highlightsPerUrl: 3 }
  }
})
```

## Review & Testing Checklist for Human

- [ ] **Test the highlights parameter against the live Exa API** - verify that passing `highlights` in contents actually returns highlight data in the response
- [ ] Verify the types match the Exa API spec (checked against `exa-spec.yaml` but worth confirming)
- [ ] Consider updating the docs at `docs/reference/vercel.mdx` to include highlights in the "All Options" section

### Notes

- Implementation follows the same pattern as the existing `summary` parameter
- Types derived from the Exa API OpenAPI spec
- Build/typecheck passes

**Link to Devin run:** https://app.devin.ai/sessions/e3f3b535be7240409fc4ac4df48bd823
**Requested by:** liam@exa.ai (@LiamHz)