### PR TITLE
Add x-exa-integration header for tracking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export function webSearch(config: ExaSearchConfig = {}) {
           headers: {
             "Content-Type": "application/json",
             "x-api-key": apiKey,
+            "x-exa-integration": "vercel-ai-sdk",
           },
           body: JSON.stringify(requestBody),
         });


### PR DESCRIPTION
## Summary

Adds the `x-exa-integration: vercel-ai-sdk` header to the Exa API search request. This enables server-side tracking of API usage originating from this Vercel AI SDK integration.

This is part of a broader effort to track first-party integrations via the `x-exa-integration` header, which will be persisted to `request_traffic.headers` and `events.events_properties` in the backend.

## Review & Testing Checklist for Human

- [ ] Verify the header value `vercel-ai-sdk` is the correct identifier for this integration
- [ ] Test that the web search tool still works correctly after the change

**Recommended test plan:** Run a simple search query using the `webSearch` tool and verify the response is returned correctly.

### Notes

Related PRs:
- [monorepo #11140](https://github.com/exa-labs/monorepo/pull/11140) - Backend tracking implementation

Link to Devin run: https://app.devin.ai/sessions/c53bee9b38344a2d86143583200735c4
Requested by: linh@exa.ai (@liinnh)