### PR TITLE
[ai-sdk]: add integration token to user-agent header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ExaSearchConfig } from "./types";
+import packageJson from "../package.json";
 
 /**
  * Creates a web search tool powered by Exa for use with Vercel AI SDK
@@ -127,7 +128,7 @@ export function webSearch(config: ExaSearchConfig = {}) {
             "Content-Type": "application/json",
             "x-api-key": apiKey,
             "x-exa-integration": "vercel-ai-sdk",
-            "User-Agent": "exa-vercel-ai-sdk 1.0.5",
+            "User-Agent": `exa-vercel-ai-sdk ${packageJson.version}`,
           },
           body: JSON.stringify(requestBody),
         });


### PR DESCRIPTION
## Summary

Adds a `User-Agent` header with value `exa-vercel-ai-sdk {version}` to API requests made by the Vercel AI SDK integration. The version is read dynamically from `package.json` at runtime. This complements the existing `x-exa-integration` header tracking.

The format follows the canonical SDK-style pattern used by official Exa SDKs (e.g., `exa-py 1.12.4`, `exa-node 2.0.11`) based on production ClickHouse data analysis.

## Updates since last revision

- Updated User-Agent format from `exa-vercel-ai-sdk` to `exa-vercel-ai-sdk {version}` to include version number
- Changed from hardcoded version to dynamic reading from `package.json` via import

## Review & Testing Checklist for Human

- [ ] Verify the `import packageJson from "../package.json"` resolves correctly at runtime (not just compile time) - the relative path assumes `dist/index.js` → `package.json`
- [ ] Test that the header is actually sent to the Exa API by making a sample request and checking server-side logs
- [ ] Confirm `tsconfig.json` has `resolveJsonModule: true` (it does, but worth double-checking)

### Notes

This is part of a broader effort to add integration tokens to User-Agent headers across exa-integrations. Browser-based integrations (like exa-for-shopping) cannot set User-Agent due to browser security restrictions, but Node.js-based integrations like this one can.

**Link to Devin run**: https://app.devin.ai/sessions/33b8e1b5063e4a9c995d8fea5709903e
**Requested by**: linh@exa.ai (@liinnh)