### PR TITLE
fix: add missing import attribute for package.json import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@exalabs/ai-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exalabs/ai-sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.3.0"
       },
       "peerDependencies": {
         "ai": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exalabs/ai-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Exa web search tool for Vercel AI SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -42,6 +42,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.3.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ExaSearchConfig } from "./types";
-import packageJson from "../package.json";
+import packageJson from "../package.json" with { type: "json" };
 
 /**
  * Creates a web search tool powered by Exa for use with Vercel AI SDK


### PR DESCRIPTION
Node ESM JSON import fix

## Problem

`@exalabs/ai-sdk` reads the package version from `package.json` via:

```ts
import packageJson from '../package.json';
```

In **Node.js ESM**, importing JSON requires an explicit **import attribute**. Without it, loading the published `dist/index.js` fails at startup (for example when the dependency is **not** bundled and Node resolves the real file under `node_modules`).

Example stack trace:

```
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "node_modules/.pnpm/@exalabs+ai-sdk@2.0.0_ai@6.0.116_zod@4.3.6_/node_modules/@exalabs/ai-sdk/package.json" needs an import attribute of "type: json"
      at validateAttributes (node:internal/modules/esm/assert:88:15)
      at defaultLoadSync (node:internal/modules/esm/load:164:3)
      at #loadAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:795:12)
      at #loadSync (node:internal/modules/esm/loader:815:49)
      at ModuleLoader.load (node:internal/modules/esm/loader:780:26)
      at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:526:31)
      at #getOrCreateModuleJobAfterResolve (node:internal/modules/esm/loader:571:36)
      at afterResolve (node:internal/modules/esm/loader:624:52)
      at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:630:12)
      at ModuleJob.syncLink (node:internal/modules/esm/module_job:143:33) {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
```

Bundlers often hide this because they resolve JSON at build time; **plain `tsc` → run with Node** does not.

## Solution

Use the standard JSON import attribute:

```ts
import packageJson from '../package.json' with { type: 'json' };
```

TypeScript emits this form into `dist/`, so Node’s ESM loader accepts the JSON import.

**References**

- Node.js: [ECMAScript modules — import attributes](https://nodejs.org/api/esm.html#import-attributes) (`with { type: 'json' }`).
- TypeScript: [TypeScript 5.3 release notes — Import attributes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html#import-attributes) (syntax supported from **5.3** onward).

`devDependencies` TypeScript is set to **`^5.3.0`** so the source parses and builds reliably.
